### PR TITLE
Fixed Flaky tests due to JSON assertion

### DIFF
--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -166,8 +167,9 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         schema,
         flattenSpec
     );
+    ObjectMapper objectMapper = new ObjectMapper();
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(objectMapper.readTree(FLAT_JSON), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test


### PR DESCRIPTION

### Description

- Fixed Flaky tests due to JSON assertion:
   - org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testFlat1Flatten
   
- The Flakiness is due to failing assertion when comparing two JSON strings.

The proposed solution compares the JSON using the objectMapper from Jackson.

## How Has This Been Tested?

### JVM version
```
openjdk 11.0.20 2023-07-18
OpenJDK Runtime Environment (build 11.0.20+8-post-Ubuntu-1ubuntu120.04)
OpenJDK 64-Bit Server VM (build 11.0.20+8-post-Ubuntu-1ubuntu120.04, mixed mode, sharing)
```
### Maven version
```
Apache Maven 3.6.3
Maven home: /usr/share/maven
Java version: 11.0.20, vendor: Ubuntu, runtime: /usr/lib/jvm/java-11-openjdk-amd64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "5.4.0-159-generic", arch: "amd64", family: "unix"
```

The steps to reproduce involves
1. Setting up the environment versions (jvm and maven) as above.
2. clone the repo
```
git clone git clone https://github.com/kavvya97/druid.git
cd druid
git rev-parse HEAD
git checkout <latest_commit_hash>
```
3. Run the [nondex](https://github.com/TestingResearchIllinois/NonDex) tool
```
mvn install -pl extensions-core/parquet-extensions -am -DskipTests |& tee mvn-test-$(date +%s).log
mvn -pl extensions-core/parquet-extensions edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testFlat1Flatten |& tee mvn-non-dex-$(date +%s).log

```
4. Test Failure screenshot
![image](https://github.com/zzjas/druid/assets/56823071/a901221a-574b-4a5a-a965-de113f223f5b)

5. Stack Code trace:
```
mvn -pl extensions-core/parquet-extensions edu.illinois:nondex-maven-plugin:2.1.1:debug - |& tee mvn-debug-$(date +%s).log
```
This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
