### PR TITLE
Fix the flaky test

### DIFF
--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -84,15 +86,21 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
     );
     List<InputRowListPlusRawValues> sampledAsString = sampleAllRows(readerAsString);
     List<InputRowListPlusRawValues> sampledAsDate = sampleAllRows(readerAsDate);
-    final String expectedJson = "{\n"
+    final String expectedJsonString = "{\n"
                                       + "  \"date_as_string\" : \"2017-06-18\",\n"
                                       + "  \"timestamp_as_timestamp\" : 1497702471815,\n"
                                       + "  \"timestamp_as_string\" : \"2017-06-17 14:27:51.815\",\n"
                                       + "  \"idx\" : 1,\n"
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()));
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()));
+
+    ObjectMapper obj = new ObjectMapper();
+    JsonNode expectedJson = obj.readTree(expectedJsonString);
+
+    JsonNode sampledAsStringJson = obj.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()));
+    JsonNode sampledAsDateJson = obj.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()));
+    Assert.assertEquals(expectedJson, sampledAsStringJson);
+    Assert.assertEquals(expectedJson, sampledAsDateJson);
   }
 
   @Test


### PR DESCRIPTION
### Description
Fixed the flaky test `testDateHandling` inside `TimestampsParquetReaderTest` class. 

https://github.com/prathyushreddylpr/druid/blob/ad32f8458670339808a3136a9578a10a52b8394f/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java#L40

#### Root Cause
The test `testDateHandling` has been reported as flaky when run with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed because it is trying to compare two Json strings, but since the JSON library used here is internally using HashMap. The HashMap in Java is implemented in such a way that it does not store the order in which the keys and values are inserted. As a result, when the expected Json string(which is hard-coded) is compared with the actual one, it caused the failure. 

#### Fix
This test is fixed using the Jackson library which contains classes JsonNode and ObjectMapper. These are used to parse two JSON strings to tree models and then compare these trees node by node. So when we use this, the order of the elements in the JSON strings is ignored and only the content is checked.

### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl infra/common -am -DskipTests
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl extensions-core/parquet-extensions test -Dtest=org.apache.druid.data.input.parquet.TimestampsParquetReaderTest#testDateHandling
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl extensions-core/parquet-extensions edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.data.input.parquet.TimestampsParquetReaderTest#testDateHandling
```

NonDex test passed after the fix.



<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.

